### PR TITLE
fix - method Pool.SetSize() may lead memory leak

### DIFF
--- a/tunny.go
+++ b/tunny.go
@@ -285,6 +285,7 @@ func (p *Pool) SetSize(n int) {
 	// Synchronously wait for all workers > N to stop
 	for i := n; i < lWorkers; i++ {
 		p.workers[i].join()
+		p.workers[i] = nil
 	}
 
 	// Remove stopped workers from slice


### PR DESCRIPTION
workers > N will leave in the underlying array, leading memory leak.