### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Jeffail/tunny
+module github.com/jeffail/tunny
 
 go 1.13


### PR DESCRIPTION
for fix go mod download error as follows:
```
github.com/jeffail/tunny: github.com/jeffail/tunny@v0.1.4: parsing go.mod:
        module declares its path as: github.com/Jeffail/tunny
                but was required as: github.com/jeffail/tunny
```