### PR TITLE
docs(example): Deprecated: As of Go 1.16,

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ example:
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 
@@ -53,7 +53,7 @@ func main() {
 	defer pool.Close()
 
 	http.HandleFunc("/work", func(w http.ResponseWriter, r *http.Request) {
-		input, err := ioutil.ReadAll(r.Body)
+		input, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 		}


### PR DESCRIPTION
https://pkg.go.dev/io/ioutil