### PR TITLE
Add Submit() API for submitting async tasks. There are good reasons for asynchronous APIs to come back.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ if err == context.DeadlineExceeded {
 }
 ```
 
+## Submitting Async Tasks
+
+`pool.Process()` is a sync API, and it will not return until the task is finished. Sometimes we need to submit async task. For async task, one simple way is: (see issue #9)
+
+```go
+go func() {
+    foo := pool.Process(MyTask)
+}()
+```
+
+However, the above method cannot control the number growth of goroutines. If there are 4 workers but 10000 tasks, the above method will create 10000 goroutines. But we wish these are only 4 worker goroutines running these tasks. In this case, `pool.Submit()` is a better choice:
+``` go
+pool.Submit(func() {
+	// put your task here
+	MyTask()
+})
+```
+
 ## Changing Pool Size
 
 The size of a Tunny pool can be changed at any time with `SetSize(int)`:


### PR DESCRIPTION
I checked the issue and it seems that async APIs is provided in the early version but now have been deprecated. In this PR I want to resume the async APIs and give out my reason.

`pool.Process()` is a sync API, and it will not return until the task is finished. Sometimes we need to submit async tasks. For running async tasks, one simple way is: (see issue #9)

```go
go func() {
    foo := pool.Process(MyTask)
}()
```

However, the above method cannot control the number growth of goroutines. If there are 4 workers but 10000 tasks, the above method will create 10000 goroutines. But we wish these are only 4 worker goroutines running these tasks. In this case, `pool.Submit()` is a better choice:
``` go
pool.Submit(func() {
	// do your task
})
```
The source code of tunny is short and elegant, but I think async APIs are necessary for a Go task pool module. Similar effects can be achieved by some indirect methods, but tunny has already provided the framework to do this in a more efficient way. So I actually only add a new API and a new Worker implementation for it, without changing the current APIs.
